### PR TITLE
Add missing alias

### DIFF
--- a/lib/mix/tasks/gen.ex
+++ b/lib/mix/tasks/gen.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Gen do
 
   use Mix.Task
 
-  alias MixTaskGen.Assigns
+  alias MixTaskGen.{Assigns, Options}
   alias MixTemplates.{Cache, Specs}
 
   # @default_options %{


### PR DESCRIPTION
Lack of this alias is causing errors:

```
** (UndefinedFunctionError) function Options.from_args/2 is undefined (module Options is not available)
    Options.from_args([], [])
    lib/mix/tasks/gen.ex:137: Mix.Tasks.Gen.generate_project/4
    (mix) lib/mix/task.ex:294: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:58: Mix.CLI.run_task/2
    (elixir) lib/code.ex:370: Code.require_file/2
```