### PR TITLE
Fix project generation when project name is capitalized

### DIFF
--- a/lib/mix/tasks/gen.ex
+++ b/lib/mix/tasks/gen.ex
@@ -93,7 +93,7 @@ defmodule Mix.Tasks.Gen do
 
     def run_command( { :new_project, template_name, project_name, args }) do
       find_template(template_name)
-      |> generate_project(template_name, project_name, args)
+      |> generate_project(template_name, String.downcase(project_name), args)
     end
 
 

--- a/test/mix_generator_test.exs
+++ b/test/mix_generator_test.exs
@@ -7,7 +7,7 @@ defmodule MixGeneratorTest do
   @child_template  Path.join(__DIR__, "../test_templates/child")
   @project_name    "cecil"
   @project_name_camel_case "Cecil"
-  
+
   test "basic project can be created" do
     in_tmp(%{
           setup: fn ->
@@ -23,12 +23,32 @@ defmodule MixGeneratorTest do
                 test/test_helper.exs
               }
               |> Enum.each(&assert_file/1)
-            
+
             assert_file("mix.exs", ~r/@name\s+:#{@project_name}/)
             assert_file("lib/#{@project_name}.ex", ~r/defmodule #{@project_name_camel_case}/)
           end})
   end
 
+  test "basic project can be created when name is capitalized" do
+    in_tmp(%{
+          setup: fn ->
+             Mix.Tasks.Gen.run([ @template, String.capitalize(@project_name) ])
+           end,
+          test: fn ->
+            ~w{ .gitignore
+                README.md
+                mix.exs
+                config/config.exs
+                lib/#{@project_name}.ex
+                test/#{@project_name}_test.exs
+                test/test_helper.exs
+              }
+              |> Enum.each(&assert_file/1)
+
+            assert_file("mix.exs", ~r/@name\s+:#{@project_name}/)
+            assert_file("lib/#{@project_name}.ex", ~r/defmodule #{@project_name_camel_case}/)
+          end})
+  end
 
   test "project with --sup can be created" do
     in_tmp(%{
@@ -66,7 +86,7 @@ defmodule MixGeneratorTest do
 
   # the child project is like project, but adds a file lib/child.ex, and removes
   # lib/#{project_name}.ex
-  
+
   test "template based on another can be created" do
     in_tmp(%{
           setup: fn ->
@@ -98,12 +118,12 @@ defmodule MixGeneratorTest do
 
             assert !File.exists?("lib/#{@project_name}.ex")
          end})
-  end  
+  end
 
   ############################################################
-  
+
   # stolen from mix/test/tasks/new
-  
+
   defp assert_file(file) do
     assert File.regular?(file), "Expected #{file} to exist, but does not"
   end
@@ -111,11 +131,11 @@ defmodule MixGeneratorTest do
   defp assert_file(file, matcher) when is_function(matcher, 1)  do
     assert_file(file)
     matcher.(File.read!(file))
-  end  
-  
+  end
+
   defp assert_file(file, match) do
     assert_file file, &(assert &1 =~ match)
-  end  
+  end
 
   def in_tmp(%{setup: setup, test: tests}) do
     System.tmp_dir!
@@ -126,9 +146,8 @@ defmodule MixGeneratorTest do
          File.cd!(@project_name, fn ->
            tests.()
          end)
-         File.rm_rf!(@project_name)      
+         File.rm_rf!(@project_name)
     end)
   end
-  
-  
+
 end


### PR DESCRIPTION
I ran into an issue today where I generated a project using a capitalized project name and then none of my files followed the usual Phoenix/Elixir standards. Instead of seeing things like 

```elixir
  def project do
    [app: :agoneum,
     version: "0.0.1",
     elixir: "~> 1.4",
     elixirc_paths: elixirc_paths(Mix.env),
     compilers: [:phoenix, :gettext] ++ Mix.compilers,
     start_permanent: Mix.env == :prod,
     aliases: aliases(),
     deps: deps()]
  end
```

they app name was generated as 

```elixir
  def project do
    [app: :Agoneum,
     version: "0.0.1",
     elixir: "~> 1.4",
     elixirc_paths: elixirc_paths(Mix.env),
     compilers: [:phoenix, :gettext] ++ Mix.compilers,
     start_permanent: Mix.env == :prod,
     aliases: aliases(),
     deps: deps()]
  end
```

While it's not a huge issue, it looks out of place in the many files that the app name appears in, especially since the Elixir/Phoenix standard (or best practice?) that people follow is to use lowercase names. This change just allows the user to enter in a capitalized name and still have their files get generated in the more idiomatic way

Ideally, maybe the parent directory would keep the capitalization that the user typed, and then any inner directories would be downcased, but that may be more effort than it's worth