### PR TITLE
Add just_files template assign

### DIFF
--- a/lib/mix/tasks/gen.ex
+++ b/lib/mix/tasks/gen.ex
@@ -170,6 +170,7 @@ defmodule Mix.Tasks.Gen do
         target_subdir:           project_name,
         template_module:         template_module,
         template_name:           template_module.name(),
+        just_files:              template_module.just_files(),
 
         elixir_version:          System.version(),
         erlang_version:          :erlang.system_info(:version),
@@ -264,7 +265,5 @@ defmodule Mix.Tasks.Gen do
         _, _ -> false
       end
     end
-
   end
-
 end


### PR DESCRIPTION
Adds the just_files templates assign, which is a whitelist for files that should be copied over directly rather than processed via EEx.