### PR TITLE
Raise a Mix.Error when a template fails to generate

### DIFF
--- a/lib/mix/tasks/gen.ex
+++ b/lib/mix/tasks/gen.ex
@@ -189,7 +189,9 @@ defmodule Mix.Tasks.Gen do
     defp create_output(assigns) do
       case MixTemplates.generate(assigns.template_module, assigns) do
         { :error, reason } ->
-          Mix.shell.info([ :red, "Error: ", :reset, reason ])
+          Mix.raise("""
+          Failed to create output for #{assigns.template_module} because #{reason}
+          """)
         :ok ->
           Mix.shell.info([ :green, "Successfully generated ",
                            :reset, assigns.project_name,

--- a/test/mix_generator_test.exs
+++ b/test/mix_generator_test.exs
@@ -120,6 +120,27 @@ defmodule MixGeneratorTest do
          end})
   end
 
+  test "template is not created if it's based on a template that fails to generate" do
+    in_tmp(%{
+          setup: fn ->
+             # simulate that the project dir already exists
+             # so that the based_on template gen fails
+             File.mkdir(@project_name)
+
+             assert_raise(Mix.Error, fn ->
+               Mix.Tasks.Gen.run([ @child_template, @project_name,
+                                   "--name_of_child", "cedric" ])
+             end)
+           end,
+          test: fn ->
+             # confirm that the setup prevented the based_on template from generating
+             assert !File.exists?("test/#{@project_name}_test.exs")
+
+             # assert that the child template did not generate
+             assert !File.exists?("lib/child.ex")
+         end})
+  end
+
   ############################################################
 
   # stolen from mix/test/tasks/new


### PR DESCRIPTION
fixes https://github.com/pragdave/mix_generator/issues/11

This makes it more clear that the overall `gen` task has failed when any of the child templates fails to generate.